### PR TITLE
change SIGKILL to SIGTERM to exit properly

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -62,7 +62,8 @@ void BambooServer::run(json config) {
 
     signal(SIGINT, signal_handler);
     signal(SIGQUIT, signal_handler);
-    signal(SIGKILL, signal_handler);
+    signal(SIGTERM, signal_handler);
+
 
     if (config["rateLimiter"] == false) manager.enableRateLimiting(false);
     


### PR DESCRIPTION
SIGKILL can not be catched, SIGTERM can. This fixes docker stop from hanging among other things