### PR TITLE
Lock less in mempool_sync to increase performance

### DIFF
--- a/src/server/mempool.cpp
+++ b/src/server/mempool.cpp
@@ -38,10 +38,7 @@ void mempool_sync(MemPool& mempool) {
         vector<future<void>> reqs;
         set<string> neighbors;
 
-        {
-            std::unique_lock<std::mutex> ul(mempool.lock);
-            neighbors = mempool.hosts.sampleFreshHosts(TX_BRANCH_FACTOR);
-        }
+        neighbors = mempool.hosts.sampleFreshHosts(TX_BRANCH_FACTOR);
 
         for(auto neighbor : neighbors) {
             Transaction newT = t;


### PR DESCRIPTION
I discovered a bug where submitting block would randomly time out http requests and all other requests to node were hanging. 

It turned out that MemPool::mempool_sync kept the locks locked even while sleeping reducing node performance when calling other MemPool methods.

This fixes the locking issue by reducing locking as much as possible. Please review that I did not miss any locks.