### PR TITLE
Remove lock that could result in deadlock

### DIFF
--- a/src/server/blockchain.cpp
+++ b/src/server/blockchain.cpp
@@ -33,7 +33,6 @@ void chain_sync(BlockChain& blockchain) {
     while(true) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10000));
         if (blockchain.shutdown) break;
-        std::unique_lock<std::mutex> ul(blockchain.lock);
         blockchain.startChainSync();
     }
 }


### PR DESCRIPTION
This lock removed from Blockchain::chain_sync could end up in deadlock and node would not synchronize blockchain after headers have been synced.

Blockchain::startChainSync method calls addBlock that uses it's own lock while doing it's things.

But, is there any other places in startChainSync that would require locking?