### PR TITLE
Pufferfish speedup

### DIFF
--- a/src/core/block.cpp
+++ b/src/core/block.cpp
@@ -152,7 +152,7 @@ vector<Transaction>& Block::getTransactions() {
 bool Block::verifyNonce() {
     SHA256Hash target = this->getHash();
     bool usePufferfish = this->getId() > PUFFERFISH_START_BLOCK;
-    return verifyHash(target, this->nonce, this->difficulty, usePufferfish);
+    return verifyHash(target, this->nonce, this->difficulty, usePufferfish, true);
 }
 
 void Block::setDifficulty(uint8_t d) {

--- a/src/core/constants.hpp
+++ b/src/core/constants.hpp
@@ -8,7 +8,7 @@
 #define TIMEOUT_SUBMIT_MS 30000
 #define BLOCKS_PER_FETCH 200
 #define BLOCK_HEADERS_PER_FETCH 2000
-#define BUILD_VERSION "0.5.8-beta"
+#define BUILD_VERSION "0.5.9-beta"
 
 
 // Files

--- a/src/core/crypto.hpp
+++ b/src/core/crypto.hpp
@@ -5,14 +5,14 @@
 #include <mutex>
 using namespace std;
 
-SHA256Hash SHA256(const char* buffer, size_t len, bool usePufferFish=false);
+SHA256Hash SHA256(const char* buffer, size_t len, bool usePufferFish=false, bool useCache=false);
 SHA256Hash SHA256(string str);
 RIPEMD160Hash  RIPEMD(const char* buffer, size_t len);
 SHA256Hash stringToSHA256(string hex);
 string SHA256toString(SHA256Hash h);
 std::vector<uint8_t> hexDecode(const string& hex);
 string hexEncode(const char* buffer, size_t len);
-SHA256Hash concatHashes(SHA256Hash& a, SHA256Hash& b, bool usePufferFish = false);
+SHA256Hash concatHashes(SHA256Hash& a, SHA256Hash& b, bool usePufferFish = false, bool useCache = false);
 bool checkLeadingZeroBits(SHA256Hash& hash, unsigned int challengeSize);
 Bigint addWork(Bigint previousWork, uint32_t challengeSize);
 
@@ -33,4 +33,4 @@ TransactionSignature signWithPrivateKey(const char* bytes, size_t len, PublicKey
 bool checkSignature(string content, TransactionSignature signature, PublicKey signingKey);
 bool checkSignature(const char* bytes, size_t len, TransactionSignature signature, PublicKey signingKey);
 SHA256Hash mineHash(SHA256Hash target, unsigned char challengeSize, bool usePufferfish=false);
-bool verifyHash(SHA256Hash& target, SHA256Hash& nonce, unsigned char challengeSize, bool usePufferfish=false);
+bool verifyHash(SHA256Hash& target, SHA256Hash& nonce, unsigned char challengeSize, bool usePufferfish = false, bool useCache = false);


### PR DESCRIPTION
Reduces CPU usage by 2x and speeds up pufferfish hash computation by caching hashes across threads.

Partially addresses https://github.com/bamboo-crypto/bamboo/issues/70