### PR TITLE
correct issues preventing compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ file(GLOB EXTERNAL_SOURCES "src/external/ed25519/*.c" "src/external/murmurhash3/
 if (UNIX)
     add_executable(tests ${CORE_SOURCES} ${SERVER_SOURCES} ${EXTERNAL_SOURCES} ./src/tests/tests.cpp)
     add_executable(server ${CORE_SOURCES} ${SERVER_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/server.cpp)
-    add_executable(cli ${CORE_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/cli.cpp)
+    add_executable(cli ${CORE_SOURCES} ${SERVER_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/cli.cpp)
     add_executable(loader ${CORE_SOURCES} ${SERVER_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/loader.cpp)
     add_executable(tx ${CORE_SOURCES} ${SERVER_SOURCES}  ${EXTERNAL_SOURCES} ./src/tools/tx.cpp)
     add_executable(miner ${CORE_SOURCES} ${SERVER_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/miner.cpp)

--- a/src/server/pufferfish_cache.cpp
+++ b/src/server/pufferfish_cache.cpp
@@ -6,13 +6,9 @@
 #include "ledger.hpp"
 using namespace std;
 
-
 leveldb::Slice sha256ToSlice(const SHA256Hash& h) {
     leveldb::Slice s2 = leveldb::Slice((const char*) h.data(), h.size());
     return s2;
-}
-
-PufferfishCache::PufferfishCache() {
 }
 
 bool PufferfishCache::hasHash(const SHA256Hash& hash) {

--- a/src/server/pufferfish_cache.hpp
+++ b/src/server/pufferfish_cache.hpp
@@ -7,7 +7,7 @@ using namespace std;
 
 class PufferfishCache : public DataStore {
     public:
-        PufferfishCache();
+        PufferfishCache() {}
         bool hasHash(const SHA256Hash& hash);
         SHA256Hash getHash(const SHA256Hash& hash);
         void setHash(const SHA256Hash& input, const SHA256Hash& hash);


### PR DESCRIPTION
PufferfishCache constructor is effectively defined twice (once in .cpp and once in .hpp);
Server sources not available to tx binary, resulting in undefined references.

```
/usr/bin/ld: CMakeFiles/cli.dir/src/core/crypto.cpp.o: in function `PUFFERFISH(char const*, unsigned long, bool)':
crypto.cpp:(.text+0x1554b): undefined reference to `DataStore::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
/usr/bin/ld: crypto.cpp:(.text+0x15583): undefined reference to `PufferfishCache::getHash(std::array<unsigned char, 32ul> const&)'
/usr/bin/ld: crypto.cpp:(.text+0x15722): undefined reference to `PufferfishCache::setHash(std::array<unsigned char, 32ul> const&, std::array<unsigned char, 32ul> const&)'
/usr/bin/ld: CMakeFiles/cli.dir/src/core/crypto.cpp.o: in function `PufferfishCache::PufferfishCache()':
crypto.cpp:(.text._ZN15PufferfishCacheC2Ev[_ZN15PufferfishCacheC5Ev]+0x14): undefined reference to `DataStore::DataStore()'
collect2: error: ld returned 1 exit status
```