### PR TITLE
Improve node boot times by parallelizing block download

### DIFF
--- a/src/core/api.cpp
+++ b/src/core/api.cpp
@@ -141,6 +141,7 @@ void readRawBlocks(string host_url, int startId, int endId, vector<Block>& block
         "Content-Type: application/octet-stream"
     },std::chrono::milliseconds{TIMEOUT_BLOCK_MS});
     std::vector<char> bytes(response.body.begin(), response.body.end());
+    if (bytes.size() < BLOCKHEADER_BUFFER_SIZE) throw std::runtime_error("Invalid data for block");
     uint8_t* buffer = (uint8_t*)bytes.data();
     uint8_t* currPtr = buffer;
     int bytesRead = 0;

--- a/src/core/constants.hpp
+++ b/src/core/constants.hpp
@@ -8,7 +8,7 @@
 #define TIMEOUT_SUBMIT_MS 30000
 #define BLOCKS_PER_FETCH 200
 #define BLOCK_HEADERS_PER_FETCH 2000
-#define BUILD_VERSION "0.6.3-beta"
+#define BUILD_VERSION "0.6.4-beta"
 
 
 // Files

--- a/src/core/header_chain.cpp
+++ b/src/core/header_chain.cpp
@@ -116,6 +116,10 @@ void HeaderChain::load() {
                 this->blockHashes.push_back(lastHash);
                 totalWork = addWork(totalWork, block.getDifficulty());
                 numBlocks++;
+
+                // update chain length + total work:
+                this->chainLength = numBlocks;
+                this->totalWork = totalWork;
             }
             if (failure) {
                 Logger::logStatus("header chain sync failed host=" + this->host);
@@ -133,8 +137,7 @@ void HeaderChain::load() {
             return;
         }
     }
-    this->chainLength = numBlocks;
-    this->totalWork = totalWork;
+
     this->failed = false;
     if (numBlocks != startBlocks) {
         // Logger::logStatus("Chain for " + this->host + " updated to length=" + to_string(this->chainLength) + " total_work=" + to_string(this->totalWork));

--- a/src/core/host_manager.cpp
+++ b/src/core/host_manager.cpp
@@ -291,6 +291,12 @@ SHA256Hash HostManager::getBlockHash(string host, uint64_t blockId) {
     return ret;
 }
 
+/*
+    Blacklists a host 
+*/
+void HostManager::blacklistHost(string host) {
+    this->blacklist.insert(host);
+}
 
 /*
     Returns N unique random hosts that have pinged us
@@ -300,7 +306,7 @@ set<string> HostManager::sampleFreshHosts(int count) {
     for (auto pair : this->hostPingTimes) {
         uint64_t lastPingAge = std::time(0) - pair.second;
         // only return peers that have pinged
-        if (lastPingAge < HOST_MIN_FRESHNESS && !isJsHost(pair.first)) { 
+        if (lastPingAge < HOST_MIN_FRESHNESS && !isJsHost(pair.first) && blacklist.find(pair.first) == blacklist.end()) { 
             freshHosts.push_back(pair.first);
         }
     }

--- a/src/core/host_manager.hpp
+++ b/src/core/host_manager.hpp
@@ -15,6 +15,7 @@ class HostManager {
         string computeAddress();
         void refreshHostList();
         void startPingingPeers();
+        void blacklistHost(string host);
 
         string getGoodHost();
         uint64_t getBlockCount();

--- a/src/server/block_store.hpp
+++ b/src/server/block_store.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <thread>
+#include <mutex>
 #include "leveldb/db.h"
 #include "../core/common.hpp"
 #include "../core/block.hpp"

--- a/src/server/blockchain.hpp
+++ b/src/server/blockchain.hpp
@@ -38,6 +38,7 @@ class BlockChain {
         BlockHeader getBlockHeader(uint32_t blockId);
         TransactionAmount getWalletValue(PublicWalletAddress addr);
         map<string, uint64_t> getHeaderChainStats();
+        void downloadRawBlocks(map<uint64_t, Block>& blockCache, uint64_t startId, uint64_t endId, int numWorkers);
         void setMemPool(MemPool * memPool);
         void initChain();
         void resetChain();


### PR DESCRIPTION
Still a lot of work to be done, but this at least improves download speeds and bootup times by starting chain download/verification in parallel with header download / verification. It also downloads much more data at a time by requesting data from multiple peers.

Ultimately we will want to parallelize both download and verification using some sort of producer/consumer queue but as I started thinking about it it required a much bigger refactor.